### PR TITLE
refactor: add session-scoped sandbox state store

### DIFF
--- a/app/api/apply-ai-code-stream/route.ts
+++ b/app/api/apply-ai-code-stream/route.ts
@@ -2,13 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { Sandbox } from '@e2b/code-interpreter';
 import type { SandboxState } from '@/types/sandbox';
 import type { ConversationState } from '@/types/conversation';
-
-declare global {
-  var conversationState: ConversationState | null;
-  var activeSandbox: any;
-  var existingFiles: Set<string>;
-  var sandboxState: SandboxState;
-}
+import { getSession } from '@/types/sandbox';
 
 interface ParsedResponse {
   explanation: string;
@@ -262,6 +256,7 @@ function parseAIResponse(response: string): ParsedResponse {
 export async function POST(request: NextRequest) {
   try {
     const { response, isEdit = false, packages = [], sandboxId } = await request.json();
+    const global = getSession(sandboxId || 'default');
     
     if (!response) {
       return NextResponse.json({

--- a/app/api/apply-ai-code/route.ts
+++ b/app/api/apply-ai-code/route.ts
@@ -1,10 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { SandboxState } from '@/types/sandbox';
 import type { ConversationState } from '@/types/conversation';
-
-declare global {
-  var conversationState: ConversationState | null;
-}
+import { getSession } from '@/types/sandbox';
 
 interface ParsedResponse {
   explanation: string;
@@ -126,15 +123,11 @@ function parseAIResponse(response: string): ParsedResponse {
   return sections;
 }
 
-declare global {
-  var activeSandbox: any;
-  var existingFiles: Set<string>;
-  var sandboxState: SandboxState;
-}
 
 export async function POST(request: NextRequest) {
   try {
-    const { response, isEdit = false, packages = [] } = await request.json();
+    const { response, isEdit = false, packages = [], sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     
     if (!response) {
       return NextResponse.json({

--- a/app/api/clear-vite-errors-cache/route.ts
+++ b/app/api/clear-vite-errors-cache/route.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
+import { getSession } from '@/types/sandbox';
 
-declare global {
-  var viteErrorsCache: { errors: any[], timestamp: number } | null;
-}
-
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const { sandboxId = 'default' } = await request.json().catch(() => ({}));
+    const global = getSession(sandboxId);
     // Clear the cache
     global.viteErrorsCache = null;
     

--- a/app/api/conversation-state/route.ts
+++ b/app/api/conversation-state/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import type { ConversationState } from '@/types/conversation';
-
-declare global {
-  var conversationState: ConversationState | null;
-}
+import { getSession } from '@/types/sandbox';
 
 // GET: Retrieve current conversation state
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const sandboxId = request.nextUrl.searchParams.get('sandboxId') || 'default';
+    const global = getSession(sandboxId);
     if (!global.conversationState) {
       return NextResponse.json({
         success: true,
@@ -32,7 +31,8 @@ export async function GET() {
 // POST: Reset or update conversation state
 export async function POST(request: NextRequest) {
   try {
-    const { action, data } = await request.json();
+    const { action, data, sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     
     switch (action) {
       case 'reset':
@@ -124,8 +124,10 @@ export async function POST(request: NextRequest) {
 }
 
 // DELETE: Clear conversation state
-export async function DELETE() {
+export async function DELETE(request: NextRequest) {
   try {
+    const sandboxId = request.nextUrl.searchParams.get('sandboxId') || 'default';
+    const global = getSession(sandboxId);
     global.conversationState = null;
     
     console.log('[conversation-state] Cleared conversation state');

--- a/app/api/create-ai-sandbox/route.ts
+++ b/app/api/create-ai-sandbox/route.ts
@@ -2,37 +2,31 @@ import { NextResponse } from 'next/server';
 import { Sandbox } from '@e2b/code-interpreter';
 import type { SandboxState } from '@/types/sandbox';
 import { appConfig } from '@/config/app.config';
-
-// Store active sandbox globally
-declare global {
-  var activeSandbox: any;
-  var sandboxData: any;
-  var existingFiles: Set<string>;
-  var sandboxState: SandboxState;
-}
+import { getSession } from '@/types/sandbox';
 
 export async function POST() {
   let sandbox: any = null;
+  const defaultSession = getSession('default');
 
   try {
     console.log('[create-ai-sandbox] Creating base sandbox...');
     
     // Kill existing sandbox if any
-    if (global.activeSandbox) {
+    if (defaultSession.activeSandbox) {
       console.log('[create-ai-sandbox] Killing existing sandbox...');
       try {
-        await global.activeSandbox.kill();
+        await defaultSession.activeSandbox.kill();
       } catch (e) {
         console.error('Failed to close existing sandbox:', e);
       }
-      global.activeSandbox = null;
+      defaultSession.activeSandbox = null;
     }
     
     // Clear existing files tracking
-    if (global.existingFiles) {
-      global.existingFiles.clear();
+    if (defaultSession.existingFiles) {
+      defaultSession.existingFiles.clear();
     } else {
-      global.existingFiles = new Set<string>();
+      defaultSession.existingFiles = new Set<string>();
     }
 
     // Create base sandbox - we'll set up Vite ourselves for full control
@@ -295,6 +289,8 @@ if os.path.exists(css_file):
 time.sleep(2)
 print('✓ Tailwind CSS should be loaded')
     `);
+
+    const global = getSession(sandboxId);
 
     // Store sandbox globally
     global.activeSandbox = sandbox;

--- a/app/api/create-zip/route.ts
+++ b/app/api/create-zip/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-declare global {
-  var activeSandbox: any;
-}
+import { getSession } from '@/types/sandbox';
 
 export async function POST(request: NextRequest) {
   try {
+    const { sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     if (!global.activeSandbox) {
       return NextResponse.json({ 
         success: false, 

--- a/app/api/detect-and-install-packages/route.ts
+++ b/app/api/detect-and-install-packages/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-declare global {
-  var activeSandbox: any;
-}
+import { getSession } from '@/types/sandbox';
 
 export async function POST(request: NextRequest) {
   try {
-    const { files } = await request.json();
+    const { files, sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     
     if (!files || typeof files !== 'object') {
       return NextResponse.json({ 

--- a/app/api/generate-ai-code-stream/route.ts
+++ b/app/api/generate-ai-code-stream/route.ts
@@ -5,6 +5,7 @@ import { createOpenAI } from '@ai-sdk/openai';
 import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { streamText } from 'ai';
 import type { SandboxState } from '@/types/sandbox';
+import { getSession } from '@/types/sandbox';
 import { selectFilesForEdit, getFileContents, formatFilesForAI } from '@/lib/context-selector';
 import { executeSearchPlan, formatSearchResultsForAI, selectTargetFile } from '@/lib/file-search-executor';
 import { FileManifest } from '@/types/file-manifest';
@@ -67,14 +68,13 @@ function analyzeUserPreferences(messages: ConversationMessage[]): {
   };
 }
 
-declare global {
-  var sandboxState: SandboxState;
-  var conversationState: ConversationState | null;
-}
+// session state is managed via getSession
 
 export async function POST(request: NextRequest) {
   try {
     const { prompt, model = 'openai/gpt-oss-20b', context, isEdit = false } = await request.json();
+    const sandboxId = context?.sandboxId || 'default';
+    const global = getSession(sandboxId);
     
     console.log('[generate-ai-code-stream] Received request:');
     console.log('[generate-ai-code-stream] - prompt:', prompt);

--- a/app/api/get-sandbox-files/route.ts
+++ b/app/api/get-sandbox-files/route.ts
@@ -1,14 +1,13 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { parseJavaScriptFile, buildComponentTree } from '@/lib/file-parser';
 import { FileManifest, FileInfo, RouteInfo } from '@/types/file-manifest';
 import type { SandboxState } from '@/types/sandbox';
+import { getSession } from '@/types/sandbox';
 
-declare global {
-  var activeSandbox: any;
-}
-
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const sandboxId = request.nextUrl.searchParams.get('sandboxId') || 'default';
+    const global = getSession(sandboxId);
     if (!global.activeSandbox) {
       return NextResponse.json({
         success: false,

--- a/app/api/install-packages/route.ts
+++ b/app/api/install-packages/route.ts
@@ -1,14 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Sandbox } from '@e2b/code-interpreter';
-
-declare global {
-  var activeSandbox: any;
-  var sandboxData: any;
-}
+import { getSession } from '@/types/sandbox';
 
 export async function POST(request: NextRequest) {
   try {
-    const { packages, sandboxId } = await request.json();
+    const { packages, sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     
     if (!packages || !Array.isArray(packages) || packages.length === 0) {
       return NextResponse.json({ 

--- a/app/api/kill-sandbox/route.ts
+++ b/app/api/kill-sandbox/route.ts
@@ -1,13 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
+import { getSession, deleteSession } from '@/types/sandbox';
 
-declare global {
-  var activeSandbox: any;
-  var sandboxData: any;
-  var existingFiles: Set<string>;
-}
-
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const { sandboxId = 'default' } = await request.json().catch(() => ({}));
+    const global = getSession(sandboxId);
     console.log('[kill-sandbox] Killing active sandbox...');
     
     let sandboxKilled = false;
@@ -30,6 +27,8 @@ export async function POST() {
       global.existingFiles.clear();
     }
     
+    deleteSession(sandboxId);
+
     return NextResponse.json({
       success: true,
       sandboxKilled,

--- a/app/api/monitor-vite-logs/route.ts
+++ b/app/api/monitor-vite-logs/route.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
+import { getSession } from '@/types/sandbox';
 
-declare global {
-  var activeSandbox: any;
-}
-
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const sandboxId = request.nextUrl.searchParams.get('sandboxId') || 'default';
+    const global = getSession(sandboxId);
     if (!global.activeSandbox) {
       return NextResponse.json({ 
         success: false, 

--- a/app/api/report-vite-error/route.ts
+++ b/app/api/report-vite-error/route.ts
@@ -1,17 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-declare global {
-  var viteErrors: any[];
-}
-
-// Initialize global viteErrors array if it doesn't exist
-if (!global.viteErrors) {
-  global.viteErrors = [];
-}
+import { getSession } from '@/types/sandbox';
 
 export async function POST(request: NextRequest) {
   try {
-    const { error, file, type = 'runtime-error' } = await request.json();
+    const { error, file, type = 'runtime-error', sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     
     if (!error) {
       return NextResponse.json({ 
@@ -37,11 +30,11 @@ export async function POST(request: NextRequest) {
     }
     
     // Add to global errors array
-    global.viteErrors.push(errorObj);
-    
+    global.viteErrors!.push(errorObj);
+
     // Keep only last 50 errors
-    if (global.viteErrors.length > 50) {
-      global.viteErrors = global.viteErrors.slice(-50);
+    if (global.viteErrors!.length > 50) {
+      global.viteErrors = global.viteErrors!.slice(-50);
     }
     
     console.log('[report-vite-error] Error reported:', errorObj);

--- a/app/api/restart-vite/route.ts
+++ b/app/api/restart-vite/route.ts
@@ -1,11 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
+import { getSession } from '@/types/sandbox';
 
-declare global {
-  var activeSandbox: any;
-}
-
-export async function POST() {
+export async function POST(request: NextRequest) {
   try {
+    const { sandboxId = 'default' } = await request.json().catch(() => ({}));
+    const global = getSession(sandboxId);
     if (!global.activeSandbox) {
       return NextResponse.json({ 
         success: false, 

--- a/app/api/run-command/route.ts
+++ b/app/api/run-command/route.ts
@@ -1,14 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { Sandbox } from '@e2b/code-interpreter';
-
-// Get active sandbox from global state (in production, use a proper state management solution)
-declare global {
-  var activeSandbox: any;
-}
+import { getSession } from '@/types/sandbox';
 
 export async function POST(request: NextRequest) {
   try {
-    const { command } = await request.json();
+    const { command, sandboxId = 'default' } = await request.json();
+    const global = getSession(sandboxId);
     
     if (!command) {
       return NextResponse.json({ 

--- a/app/api/sandbox-logs/route.ts
+++ b/app/api/sandbox-logs/route.ts
@@ -1,11 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
-
-declare global {
-  var activeSandbox: any;
-}
+import { getSession } from '@/types/sandbox';
 
 export async function GET(request: NextRequest) {
   try {
+    const sandboxId = request.nextUrl.searchParams.get('sandboxId') || 'default';
+    const global = getSession(sandboxId);
     if (!global.activeSandbox) {
       return NextResponse.json({ 
         success: false, 

--- a/app/api/sandbox-status/route.ts
+++ b/app/api/sandbox-status/route.ts
@@ -1,13 +1,10 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
+import { getSession } from '@/types/sandbox';
 
-declare global {
-  var activeSandbox: any;
-  var sandboxData: any;
-  var existingFiles: Set<string>;
-}
-
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
+    const sandboxId = request.nextUrl.searchParams.get('sandboxId') || 'default';
+    const global = getSession(sandboxId);
     // Check if sandbox exists
     const sandboxExists = !!global.activeSandbox;
     

--- a/types/sandbox.ts
+++ b/types/sandbox.ts
@@ -1,4 +1,5 @@
-// Global types for sandbox file management
+// Scoped session state management for sandboxes and related data
+import type { ConversationState } from './conversation';
 
 export interface SandboxFile {
   content: string;
@@ -9,7 +10,8 @@ export interface SandboxFileCache {
   files: Record<string, SandboxFile>;
   lastSync: number;
   sandboxId: string;
-  manifest?: any; // FileManifest type from file-manifest.ts
+  // FileManifest type from file-manifest.ts
+  manifest?: any;
 }
 
 export interface SandboxState {
@@ -21,11 +23,39 @@ export interface SandboxState {
   } | null;
 }
 
-// Declare global types
-declare global {
-  var activeSandbox: any;
-  var sandboxState: SandboxState;
-  var existingFiles: Set<string>;
+export interface SessionState {
+  activeSandbox: any;
+  sandboxData: { sandboxId: string; url: string } | null;
+  existingFiles: Set<string>;
+  sandboxState: SandboxState;
+  conversationState: ConversationState | null;
+  viteErrors?: any[];
+  viteErrorsCache?: { errors: any[]; timestamp: number } | null;
 }
 
-export {};
+const sessionStore = new Map<string, SessionState>();
+
+export function getSession(sessionId: string): SessionState {
+  let session = sessionStore.get(sessionId);
+  if (!session) {
+    session = {
+      activeSandbox: null,
+      sandboxData: null,
+      existingFiles: new Set<string>(),
+      sandboxState: {
+        fileCache: null,
+        sandbox: null,
+        sandboxData: null,
+      },
+      conversationState: null,
+      viteErrors: [],
+      viteErrorsCache: null,
+    };
+    sessionStore.set(sessionId, session);
+  }
+  return session;
+}
+
+export function deleteSession(sessionId: string) {
+  sessionStore.delete(sessionId);
+}


### PR DESCRIPTION
## Summary
- use Map-backed session store for sandbox and conversation state
- refactor API routes to fetch session data instead of using globals
- ensure cleanup removes session entries

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e6787225c8332a160447650039ed8